### PR TITLE
Add Flask models and DB schema

### DIFF
--- a/backend/flask_app/__init__.py
+++ b/backend/flask_app/__init__.py
@@ -1,0 +1,13 @@
+"""Flask application database configuration."""
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+
+
+def init_db(app: Flask) -> None:
+    """Initialize database settings for the Flask app."""
+    app.config.setdefault("SQLALCHEMY_DATABASE_URI", "sqlite:///tasks.db")
+    app.config.setdefault("SQLALCHEMY_TRACK_MODIFICATIONS", False)
+    db.init_app(app)

--- a/backend/flask_app/models.py
+++ b/backend/flask_app/models.py
@@ -1,0 +1,45 @@
+"""SQLAlchemy models for tasks and tags."""
+from __future__ import annotations
+
+from . import db
+
+# Association table for the many-to-many relation between tasks and tags
+
+task_tags = db.Table(
+    "task_tags",
+    db.Column("task_id", db.Integer, db.ForeignKey("tasks.id"), primary_key=True),
+    db.Column("tag_id", db.Integer, db.ForeignKey("tags.id"), primary_key=True),
+)
+
+
+class Task(db.Model):
+    """Represents a task item."""
+
+    __tablename__ = "tasks"
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(80), nullable=False)
+    description = db.Column(db.Text)
+
+    tags = db.relationship(
+        "Tag", secondary=task_tags, back_populates="tasks", lazy="dynamic"
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - simple representation
+        return f"<Task {self.title}>"
+
+
+class Tag(db.Model):
+    """Represents a label attached to a task."""
+
+    __tablename__ = "tags"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(50), unique=True, nullable=False)
+
+    tasks = db.relationship(
+        "Task", secondary=task_tags, back_populates="tags", lazy="dynamic"
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - simple representation
+        return f"<Tag {self.name}>"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,5 @@ gspread
 oauth2client
 smtplib
 email
+Flask
+Flask-SQLAlchemy

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,0 +1,21 @@
+-- SQL schema for managing tasks and tags
+-- Provides many-to-many relationship between tasks and tags
+
+CREATE TABLE tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title VARCHAR(80) NOT NULL,
+    description TEXT
+);
+
+CREATE TABLE tags (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name VARCHAR(50) NOT NULL UNIQUE
+);
+
+CREATE TABLE task_tags (
+    task_id INTEGER NOT NULL,
+    tag_id INTEGER NOT NULL,
+    PRIMARY KEY (task_id, tag_id),
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- add SQL schema for tasks, tags and their association
- introduce Flask SQLAlchemy initialization
- implement `Task` and `Tag` models with many-to-many relation
- update backend requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6852b057070883338e0814ba821e6ed8